### PR TITLE
Add support for VisionOS and swift5.8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     name: "RenderLock",
     platforms: [
         .iOS(.v14),
+        .visionOS(.v1)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "RenderLock",
+    platforms: [
+        .iOS(.v14),
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "RenderLock",
+            targets: ["RenderLock"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "RenderLock"),
+        .testTarget(
+            name: "RenderLockTests",
+            dependencies: ["RenderLock"]),
+    ]
+)


### PR DESCRIPTION
`SwiftUI-Refresher` [added support for visionOS](https://github.com/gh123man/SwiftUI-Refresher/commit/9e1948c6597ef890f51edfe8279601718763c7b8), but couldn't build due to a lack of support for `SwiftUI-RenderLock`. Therefore, support for visionOS was added. Additionally, it now simultaneously supports building with Swift versions 5.8 and below

